### PR TITLE
Make permission checking optional in permitted contracts

### DIFF
--- a/SmartContracts.NET/ContractsCore.Tests/Mocks/FavoriteNumberContract.cs
+++ b/SmartContracts.NET/ContractsCore.Tests/Mocks/FavoriteNumberContract.cs
@@ -15,7 +15,7 @@ namespace ContractsCore.Tests.Mocks
 
 		protected internal override object GetState() => this.Number;
 
-		protected override bool HandleAcceptedAction(Action action)
+		protected override bool HandleReceivedAction(Action action)
 		{
 			switch (action)
 			{

--- a/SmartContracts.NET/ContractsCore.Tests/Mocks/PermittedFavoriteNumberContract.cs
+++ b/SmartContracts.NET/ContractsCore.Tests/Mocks/PermittedFavoriteNumberContract.cs
@@ -20,7 +20,7 @@ namespace ContractsCore.Tests.Mocks
 
 		protected internal override object GetState() => this.Number;
 
-		protected override bool HandleAcceptedAction(Action action)
+		protected override bool HandleReceivedAction(Action action)
 		{
 			switch (action)
 			{
@@ -33,9 +33,10 @@ namespace ContractsCore.Tests.Mocks
 			}
 		}
 
-		private void HandleSetNumberAction(SetFavoriteNumberAction favoriteNumberAction)
+		private void HandleSetNumberAction(SetFavoriteNumberAction action)
 		{
-			this.Number = favoriteNumberAction.Number;
+			this.RequirePermission(action);
+			this.Number = action.Number;
 		}
 	}
 }

--- a/SmartContracts.NET/ContractsCore/Contracts/Contract.cs
+++ b/SmartContracts.NET/ContractsCore/Contracts/Contract.cs
@@ -26,10 +26,10 @@ namespace ContractsCore.Contracts
 				throw new ArgumentNullException(nameof(action));
 			}
 
-			return this.HandleAcceptedAction(action);
+			return this.HandleReceivedAction(action);
 		}
 
-		protected abstract bool HandleAcceptedAction(Action action);
+		protected abstract bool HandleReceivedAction(Action action);
 
 		protected virtual void Redirect(Action action)
 		{


### PR DESCRIPTION
Make permission checking optional in permitted contracts, so they can decide whether to accept or deny actions which don't have explicit permissions